### PR TITLE
Fix homomorphic product test

### DIFF
--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -11,8 +11,8 @@ pub fn decrypt(
 	let mut decrypted_coeffs = vec![];
 	let mut s;
 	for c in scaled_pt.coeffs().iter() {
-		s = nearest_int(c*t,q) % t;
-		decrypted_coeffs.push(s);
+		s = nearest_int(c*t,q);
+		decrypted_coeffs.push(s.rem_euclid(t));
 	}
     Polynomial::new(decrypted_coeffs)
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -7,13 +7,13 @@ pub fn encrypt(
     params: &Parameters,       //parameters (n,q,t,f)
     seed: Option<u64>            // Seed for random number generator
 ) -> (Polynomial<i64>, Polynomial<i64>) {
-    let (n,q,t,f) = (params.n, params.q, params.t, &params.f);
+    let (n,q,t,f,sigma) = (params.n, params.q, params.t, &params.f, params.sigma);
     // Scale the plaintext polynomial. use floor(m*q/t) rather than floor (q/t)*m
     let scaled_m = mod_coeffs(m * q / t, q);
 
     // Generate random polynomials
-    let e1 = gen_normal_poly(n, seed);
-    let e2 = gen_normal_poly(n, seed);
+    let e1 = gen_normal_poly(n, sigma, seed);
+    let e2 = gen_normal_poly(n, sigma, seed);
     let u = gen_binary_poly(n, seed);
 
     // Compute ciphertext components

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -17,8 +17,8 @@ pub fn encrypt(
     let u = gen_ternary_poly(n, seed);
 
     // Compute ciphertext components
-    let ct0 = polyadd(&polyadd(&polymul(&pk[0], &u, q*q, f), &e1, q*q, f),&scaled_m,q*q,f);
-    let ct1 = polyadd(&polymul(&pk[1], &u, q*q, f), &e2, q*q, f);
+    let ct0 = polyadd(&polyadd(&polymul(&pk[0], &u, q, f), &e1, q, f),&scaled_m,q,f);
+    let ct1 = polyadd(&polymul(&pk[1], &u, q, f), &e2, q, f);
 
     (ct0, ct1)
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -17,8 +17,8 @@ pub fn encrypt(
     let u = gen_binary_poly(n, seed);
 
     // Compute ciphertext components
-    let ct0 = polyadd(&polyadd(&polymul(&pk[0], &u, q, f), &e1, q, f),&scaled_m,q,f);
-    let ct1 = polyadd(&polymul(&pk[1], &u, q, f), &e2, q, f);
+    let ct0 = polyadd(&polyadd(&polymul(&pk[0], &u, q*q, f), &e1, q*q, f),&scaled_m,q*q,f);
+    let ct1 = polyadd(&polymul(&pk[1], &u, q*q, f), &e2, q*q, f);
 
     (ct0, ct1)
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -1,5 +1,5 @@
 use polynomial_ring::Polynomial;
-use ring_lwe::{Parameters, mod_coeffs, polymul, polyadd, gen_binary_poly, gen_normal_poly};
+use ring_lwe::{Parameters, mod_coeffs, polymul, polyadd, gen_ternary_poly};
 
 pub fn encrypt(
     pk: &[Polynomial<i64>; 2],    // Public key (b, a)
@@ -7,14 +7,14 @@ pub fn encrypt(
     params: &Parameters,       //parameters (n,q,t,f)
     seed: Option<u64>            // Seed for random number generator
 ) -> (Polynomial<i64>, Polynomial<i64>) {
-    let (n,q,t,f,sigma) = (params.n, params.q, params.t, &params.f, params.sigma);
+    let (n,q,t,f) = (params.n, params.q, params.t, &params.f);
     // Scale the plaintext polynomial. use floor(m*q/t) rather than floor (q/t)*m
     let scaled_m = mod_coeffs(m * q / t, q);
 
     // Generate random polynomials
-    let e1 = gen_normal_poly(n, sigma, seed);
-    let e2 = gen_normal_poly(n, sigma, seed);
-    let u = gen_binary_poly(n, seed);
+    let e1 = gen_ternary_poly(n, seed);
+    let e2 = gen_ternary_poly(n, seed);
+    let u = gen_ternary_poly(n, seed);
 
     // Compute ciphertext components
     let ct0 = polyadd(&polyadd(&polymul(&pk[0], &u, q*q, f), &e1, q*q, f),&scaled_m,q*q,f);

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -11,7 +11,7 @@ pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], 
     let sk = gen_ternary_poly(n, seed);
     let a = gen_ternary_poly(n, seed);
     let e = gen_ternary_poly(n, seed);
-    let b = polyadd(&polymul(&polyinv(&a,q*q), &sk, q*q, &f), &polyinv(&e,q*q), q*q, &f);
+    let b = polyadd(&polymul(&polyinv(&a,q), &sk, q, &f), &polyinv(&e,q), q, &f);
     
     // Return public key (b, a) as an array and secret key (sk)
     ([b, a], sk)

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,5 +1,5 @@
 use polynomial_ring::Polynomial;
-use ring_lwe::{Parameters, polymul, polyadd, polyinv, gen_binary_poly, gen_uniform_poly, gen_normal_poly};
+use ring_lwe::{Parameters, polymul, polyadd, polyinv, gen_uniform_poly, gen_normal_poly};
 use std::collections::HashMap;
 
 pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], Polynomial<i64>) {
@@ -8,7 +8,7 @@ pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], 
     let (n, q, f, sigma) = (params.n, params.q, &params.f, params.sigma);
 
     // Generate a public and secret key
-    let sk = gen_normal_poly(n,sigma, seed);
+    let sk = gen_normal_poly(n, sigma, seed);
     let a = gen_uniform_poly(n, q, seed);
     let e = gen_normal_poly(n, sigma, seed);
     let b = polyadd(&polymul(&polyinv(&a,q*q), &sk, q*q, &f), &polyinv(&e,q*q), q*q, &f);

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,16 +1,16 @@
 use polynomial_ring::Polynomial;
-use ring_lwe::{Parameters, polymul, polyadd, polyinv, gen_uniform_poly, gen_normal_poly};
+use ring_lwe::{Parameters, polymul, polyadd, polyinv, gen_ternary_poly};
 use std::collections::HashMap;
 
 pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], Polynomial<i64>) {
 
     //rename parameters
-    let (n, q, f, sigma) = (params.n, params.q, &params.f, params.sigma);
+    let (n, q, f) = (params.n, params.q, &params.f);
 
     // Generate a public and secret key
-    let sk = gen_normal_poly(n, sigma, seed);
-    let a = gen_uniform_poly(n, q, seed);
-    let e = gen_normal_poly(n, sigma, seed);
+    let sk = gen_ternary_poly(n, seed);
+    let a = gen_ternary_poly(n, seed);
+    let e = gen_ternary_poly(n, seed);
     let b = polyadd(&polymul(&polyinv(&a,q*q), &sk, q*q, &f), &polyinv(&e,q*q), q*q, &f);
     
     // Return public key (b, a) as an array and secret key (sk)

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -11,7 +11,7 @@ pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], 
     let sk = gen_binary_poly(n,seed);
     let a = gen_uniform_poly(n, q, seed);
     let e = gen_normal_poly(n, seed);
-    let b = polyadd(&polymul(&polyinv(&a,q), &sk, q, &f), &polyinv(&e,q), q, &f);
+    let b = polyadd(&polymul(&polyinv(&a,q*q), &sk, q*q, &f), &polyinv(&e,q*q), q*q, &f);
     
     // Return public key (b, a) as an array and secret key (sk)
     ([b, a], sk)

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -5,12 +5,12 @@ use std::collections::HashMap;
 pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], Polynomial<i64>) {
 
     //rename parameters
-    let (n, q, f) = (params.n, params.q, &params.f);
+    let (n, q, f, sigma) = (params.n, params.q, &params.f, params.sigma);
 
     // Generate a public and secret key
-    let sk = gen_binary_poly(n,seed);
+    let sk = gen_normal_poly(n,sigma, seed);
     let a = gen_uniform_poly(n, q, seed);
-    let e = gen_normal_poly(n, seed);
+    let e = gen_normal_poly(n, sigma, seed);
     let b = polyadd(&polymul(&polyinv(&a,q*q), &sk, q*q, &f), &polyinv(&e,q*q), q*q, &f);
     
     // Return public key (b, a) as an array and secret key (sk)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub struct Parameters {
 impl Default for Parameters {
     fn default() -> Self {
         let n = 16;
-        let q = 1073741824;
+        let q = 65536;
         let t = 512;
         let mut poly_vec = vec![0i64;n+1];
         poly_vec[0] = 1;
@@ -33,12 +33,17 @@ pub fn mod_coeffs(x : Polynomial<i64>, modulus : i64) -> Polynomial<i64> {
 	//	polynomial in Z_modulus[X]
 	let coeffs = x.coeffs();
 	let mut newcoeffs = vec![];
+	let mut c;
 	if coeffs.len() == 0 {
 		// return original input for the zero polynomial
 		x
 	} else {
 		for i in 0..coeffs.len() {
-			newcoeffs.push(coeffs[i].rem_euclid(modulus));
+			c = coeffs[i].rem_euclid(modulus);
+			if c > modulus/2 {
+				c = c-modulus;
+			}
+			newcoeffs.push(c);
 		}
 		Polynomial::new(newcoeffs)
 	}
@@ -122,7 +127,7 @@ pub fn gen_uniform_poly(size: usize, q: i64, seed: Option<u64>) -> Polynomial<i6
 	for i in 0..size {
 		coeffs[i] = between.sample(&mut rng);
 	}
-	Polynomial::new(coeffs)
+	mod_coeffs(Polynomial::new(coeffs),q)
 }
 
 pub fn gen_normal_poly(size: usize, seed: Option<u64>) -> Polynomial<i64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,18 +9,20 @@ pub struct Parameters {
     pub q: i64,       // Ciphertext modulus
     pub t: i64,       // Plaintext modulus
     pub f: Polynomial<i64>, // Polynomial modulus (x^n + 1 representation)
+    pub sigma: f64,    // Standard deviation for normal distribution
 }
 
 impl Default for Parameters {
     fn default() -> Self {
         let n = 16;
-        let q = 65536;
+        let q = 1048576;
         let t = 512;
         let mut poly_vec = vec![0i64;n+1];
         poly_vec[0] = 1;
         poly_vec[n] = 1;
         let f = Polynomial::new(poly_vec);
-        Parameters { n, q, t, f }
+        let sigma = 8.0;
+        Parameters { n, q, t, f, sigma}
     }
 }
 
@@ -130,14 +132,14 @@ pub fn gen_uniform_poly(size: usize, q: i64, seed: Option<u64>) -> Polynomial<i6
 	mod_coeffs(Polynomial::new(coeffs),q)
 }
 
-pub fn gen_normal_poly(size: usize, seed: Option<u64>) -> Polynomial<i64> {
+pub fn gen_normal_poly(size: usize, sigma: f64, seed: Option<u64>) -> Polynomial<i64> {
     //Generates a polynomial with coeffecients in a normal distribution
     //of mean 0 and a standard deviation of 2, then discretize it.
     //Args:
     //	size: number of coeffcients,
     //Returns:
     //	polynomial of degree size-1
-	let normal = Normal::new(0.0 as f64, 2.0 as f64).unwrap();
+	let normal = Normal::new(0.0 as f64, sigma).unwrap();
     let mut rng = match seed {
         Some(seed) => StdRng::seed_from_u64(seed),
         None => StdRng::from_entropy(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ impl Default for Parameters {
     fn default() -> Self {
         let n = 16;
         let q = 1048576;
-        let t = 512;
+        let t = 256;
         let mut poly_vec = vec![0i64;n+1];
         poly_vec[0] = 1;
         poly_vec[n] = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub struct Parameters {
 
 impl Default for Parameters {
     fn default() -> Self {
-        let n = 16;
+        let n = 64;
         let q = 1048576;
         let t = 256;
         let mut poly_vec = vec![0i64;n+1];
@@ -103,6 +103,24 @@ pub fn gen_binary_poly(size : usize, seed: Option<u64>) -> Polynomial<i64> {
     //Returns:
     //	polynomial of degree size-1
 	let between = Uniform::new(0,2);
+    let mut rng = match seed {
+        Some(seed) => StdRng::seed_from_u64(seed),
+        None => StdRng::from_entropy(),
+    };
+    let mut coeffs = vec![0i64;size];
+	for i in 0..size {
+		coeffs[i] = between.sample(&mut rng);
+	}
+	Polynomial::new(coeffs)
+}
+
+pub fn gen_ternary_poly(size : usize, seed: Option<u64>) -> Polynomial<i64> {
+    //Generates a polynomial with coeffecients in [0, 1]
+    //Args:
+    //	size: number of coeffcients
+    //Returns:
+    //	polynomial of degree size-1 with coeffs in {-1,0,+1}
+	let between = Uniform::new(-1,2);
     let mut rng = match seed {
         Some(seed) => StdRng::seed_from_u64(seed),
         None => StdRng::from_entropy(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,15 @@ pub fn polyadd(x : &Polynomial<i64>, y : &Polynomial<i64>, modulus : i64, f : &P
 }
 
 pub fn polyinv(x : &Polynomial<i64>, modulus: i64) -> Polynomial<i64> {
-  //Additive inverse of polynomial x modulo modulus
-  let y = -x;
-  mod_coeffs(y, modulus)
-}
+    //Additive inverse of polynomial x modulo modulus
+    let y = -x;
+    if modulus != 0{
+      mod_coeffs(y, modulus)
+    }
+    else {
+      y
+    }
+  }
 
 pub fn polysub(x : &Polynomial<i64>, y : &Polynomial<i64>, modulus : i64, f : Polynomial<i64>) -> Polynomial<i64> {
     //Subtract two polynoms

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,13 @@ pub fn polyadd(x : &Polynomial<i64>, y : &Polynomial<i64>, modulus : i64, f : &P
     //Returns:
     //	polynomial in Z_modulus[X]/(f).
 	let mut r = x+y;
-	r = mod_coeffs(r, modulus);
-	r.division(f);
-	mod_coeffs(r, modulus)
+    r.division(f);
+    if modulus != 0 {
+        mod_coeffs(r, modulus)
+    }
+    else{
+        r
+    }
 }
 
 pub fn polyinv(x : &Polynomial<i64>, modulus: i64) -> Polynomial<i64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub struct Parameters {
 
 impl Default for Parameters {
     fn default() -> Self {
-        let n = 64;
+        let n = 512;
         let q = 1048576;
         let t = 256;
         let mut poly_vec = vec![0i64;n+1];

--- a/src/test.rs
+++ b/src/test.rs
@@ -35,7 +35,7 @@ mod tests {
         });
         let m1_poly = Polynomial::new({
             let mut v = vec![0i64; params.n];
-            v[0] = 2;
+            v[0] = 3;
             v
         });
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -94,7 +94,6 @@ mod tests {
         let c1_sk = &polymul(&c.1,&sk,q*q,&f);
         let c2_sk_squared = &polymul(&polymul(&c.2,&sk,q*q,&f),&sk,q*q,&f);
         let ciphertext_prod = polyadd(&polyadd(&c.0,c1_sk,q*q,&f),c2_sk_squared,q*q,&f);
-        println!("ciphertext_prod: {:?}", ciphertext_prod);
         //let delta = q / t, divide coeffs by 1 / delta^2
         let delta = q / t;
         let decrypted_prod = mod_coeffs(Polynomial::new(ciphertext_prod.coeffs().iter().map(|&coeff| nearest_int(coeff,delta * delta) ).collect::<Vec<_>>()),t);

--- a/src/test.rs
+++ b/src/test.rs
@@ -94,6 +94,7 @@ mod tests {
         let c1_sk = &polymul(&c.1,&sk,q*q,&f);
         let c2_sk_squared = &polymul(&polymul(&c.2,&sk,q*q,&f),&sk,q*q,&f);
         let ciphertext_prod = polyadd(&polyadd(&c.0,c1_sk,q*q,&f),c2_sk_squared,q*q,&f);
+        println!("ciphertext_prod: {:?}", ciphertext_prod);
         //let delta = q / t, divide coeffs by 1 / delta^2
         let delta = q / t;
         let decrypted_prod = mod_coeffs(Polynomial::new(ciphertext_prod.coeffs().iter().map(|&coeff| nearest_int(coeff,delta * delta) ).collect::<Vec<_>>()),t);


### PR DESCRIPTION
This fixes the flaky and failing homomorphic product test dec(enc(2)*enc(3)) == 6. 

The issue was primarily with how random polynomials are generated. This differs greatly from Sage to Rust. In Sage, the coefficients essentially come from ZZ.random_element() which gives {-1,0,+1} with probability ~1/5. This is coincidentally about what you need for a notion of "small" as described in [Stange's notes](https://math.colorado.edu/~kstange/teaching-resources/crypto/RingLWE-notes.pdf), where ternary polynomials are used. Sage also does arithmetic and holds coefficients in ZZ, even in quotient rings like Z_q[x]/(x^n+1). 

One could also use a normal distribution with some std. deviation sigma centered around zero, which also gives a "small" polynomial, however there is the potential for large coefficients, particularly if sigma is large. 

We need to further explore the security implications of different choices.

When polynomials aren't small, the coefficients of the resulting products are very large. This effect is masked when working mod q. Working mod q^2 or over ZZ (q=0) allows one to sometimes get the right answer. Problems occur when you need to divide by delta*delta, and if q < delta*delta, then there's no way to get anything greater than 0. For instance, to get a result of 6 with q=32768 and t=256, delta = 128, delta^2 = 16384, and the constant coefficient in the final polynomial needs to be 98304 > q. 

Using ternary polynomials generated uniformly from {-1,0,+1} for all "small" polynomials seems to alleviate the failing homomorphic product issue, and all tests are passing even with parameters like `n=512`.