### PR TITLE
use normal poly for a

### DIFF
--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,5 +1,5 @@
 use polynomial_ring::Polynomial;
-use ring_lwe::{Parameters, polymul, polyadd, polyinv, gen_ternary_poly};
+use ring_lwe::{Parameters, polymul, polyadd, polyinv, gen_ternary_poly, gen_normal_poly};
 use std::collections::HashMap;
 
 pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], Polynomial<i64>) {
@@ -9,7 +9,7 @@ pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], 
 
     // Generate a public and secret key
     let sk = gen_ternary_poly(n, seed);
-    let a = gen_ternary_poly(n, seed);
+    let a = gen_normal_poly(n, params.sigma, seed);
     let e = gen_ternary_poly(n, seed);
     let b = polyadd(&polymul(&polyinv(&a,q), &sk, q, &f), &polyinv(&e,q), q, &f);
     


### PR DESCRIPTION
the choice of which distribution to use to randomly generate the polynomial `a` is sensitive. while using a ternary polynomial works, it may not be secure. ideally we would use a polynomial generated from a uniform distribution on [0,q-1], but that seems to break the tests. 