### PR TITLE
work mod q^2 to allow uniform a

### DIFF
--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -17,8 +17,8 @@ pub fn encrypt(
     let u = gen_ternary_poly(n, seed);
 
     // Compute ciphertext components
-    let ct0 = polyadd(&polyadd(&polymul(&pk[0], &u, q, f), &e1, q, f),&scaled_m,q,f);
-    let ct1 = polyadd(&polymul(&pk[1], &u, q, f), &e2, q, f);
+    let ct0 = polyadd(&polyadd(&polymul(&pk[0], &u, q*q, f), &e1, q*q, f),&scaled_m,q*q,f);
+    let ct1 = polyadd(&polymul(&pk[1], &u, q*q, f), &e2, q*q, f);
 
     (ct0, ct1)
 }

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,5 +1,5 @@
 use polynomial_ring::Polynomial;
-use ring_lwe::{Parameters, polymul, polyadd, polyinv, gen_ternary_poly, gen_normal_poly};
+use ring_lwe::{Parameters, polymul, polyadd, polyinv, gen_ternary_poly, gen_uniform_poly};
 use std::collections::HashMap;
 
 pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], Polynomial<i64>) {
@@ -9,9 +9,9 @@ pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], 
 
     // Generate a public and secret key
     let sk = gen_ternary_poly(n, seed);
-    let a = gen_normal_poly(n, params.sigma, seed);
+    let a = gen_uniform_poly(n, q, seed);
     let e = gen_ternary_poly(n, seed);
-    let b = polyadd(&polymul(&polyinv(&a,q), &sk, q, &f), &polyinv(&e,q), q, &f);
+    let b = polyadd(&polymul(&polyinv(&a,q*q), &sk, q*q, &f), &polyinv(&e,q*q), q*q, &f);
     
     // Return public key (b, a) as an array and secret key (sk)
     ([b, a], sk)


### PR DESCRIPTION
changed keygen and encrypt computations to be done mod q^2, so that homomorphic product would work with uniformly chosen a.