### PR TITLE
add benchmarking to measure time for polymul, polymul_fast

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1,0 +1,60 @@
+use std::time::Instant;
+use ring_lwe::{polymul, polymul_fast, Parameters, gen_uniform_poly};
+use polynomial_ring::Polynomial;
+
+fn main() {
+    benchmark_polymul_small();
+    benchmark_polymul_uniform();
+}
+
+fn benchmark_polymul_small() {
+    let p: i64 = 17; // Prime modulus
+    let root: i64 = 3; // Primitive root of unity for the modulus
+    let params = Parameters::default();
+
+    // Input polynomials (padded to length `n`)
+    let a = Polynomial::new(vec![1, 2, 3, 4]);
+    let b = Polynomial::new(vec![5, 6, 7, 8]);
+
+    // Time standard multiplication
+    let start_std = Instant::now();
+    let c_std = polymul(&a, &b, p, &params.f);
+    let duration_std = start_std.elapsed();
+    println!("Standard multiplication took: {:?}", duration_std);
+
+    // Time fast multiplication
+    let start_fast = Instant::now();
+    let c_fast = polymul_fast(&a, &b, p, &params.f, root);
+    let duration_fast = start_fast.elapsed();
+    println!("Fast multiplication took: {:?}", duration_fast);
+
+    // Verify correctness
+    assert_eq!(c_std, c_fast, "Benchmark failed: {} != {}", c_std, c_fast);
+}
+
+fn benchmark_polymul_uniform() {
+    let seed = None; // Set the random seed
+    let p: i64 = 12289; // Prime modulus
+    let root: i64 = 11; // Primitive root of unity for the modulus
+    let params = Parameters::default();
+
+    // Input polynomials (padded to length `n`)
+    let a = gen_uniform_poly(params.n, p, seed);
+    let b = gen_uniform_poly(params.n, p, seed);
+
+    // Time standard multiplication
+    let start_std = Instant::now();
+    let c_std = polymul(&a, &b, p, &params.f);
+    let duration_std = start_std.elapsed();
+    println!("Standard multiplication took: {:?}", duration_std);
+
+    // Time fast multiplication
+    let start_fast = Instant::now();
+    let c_fast = polymul_fast(&a, &b, p, &params.f, root);
+    let duration_fast = start_fast.elapsed();
+    println!("Fast multiplication took: {:?}", duration_fast);
+
+    // Verify correctness
+    assert_eq!(c_std, c_fast, "Benchmark failed: {} != {}", c_std, c_fast);
+}
+

--- a/src/test.rs
+++ b/src/test.rs
@@ -101,7 +101,7 @@ mod tests {
         assert_eq!(plaintext_prod, decrypted_prod, "test failed: {} != {}", plaintext_prod, decrypted_prod);
     }
 
-    // Test homomorphic multiplication property: product of encrypted plaintexts should decrypt to plaintext product
+    // Test fast polynomial multiplcation using NTT for small example polynomials
     #[test]
     pub fn test_polymul_fast() {
         let p: i64 = 17; // Prime modulus
@@ -118,7 +118,7 @@ mod tests {
         assert_eq!(c_std, c_fast, "test failed: {} != {}", c_std, c_fast);
     }
 
-    // Test homomorphic multiplication property: product of encrypted plaintexts should decrypt to plaintext product
+    // Test fast polynomial multiplication with the NTT for uniformly random polynomials degree n
     #[test]
     pub fn test_polymul_fast_uniform() {
         let seed = None; //set the random seed


### PR DESCRIPTION
Add two benchmarking tests, one for small polynomial multiplication and one for polynomials of degree n (default is n=512).

Note that currently:

```
Standard multiplication took: 11.458µs
Fast multiplication took: 19.292µs
Standard multiplication took: 3.399625ms
Fast multiplication took: 10.0545ms
```

So fast multiplication is currently slower than naive multiplication. 