### PR TITLE
use polyrem in polymul_fast to improve speed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub fn polymul_fast(
 
     // Construct the result polynomial and reduce modulo f
     let mut r = Polynomial::new(r_coeffs);
-    r.division(f);
+    r = polyrem(r,f);
     mod_coeffs(r, q)
 }
 


### PR DESCRIPTION
Using `polyrem` rather than long division in polymul_fast results in a significant speedup. The benchmarks now show:

```
Standard multiplication took: 13.125µs
Fast multiplication took: 42.541µs
Standard multiplication took: 10.607458ms
Fast multiplication took: 2.235958ms
```