### PR TITLE
use bitwise encoding vs. bytes

### DIFF
--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -18,8 +18,7 @@ pub fn decrypt(
 }
 
 pub fn decrypt_string(sk_string: &String, ciphertext_string: &String, params: &Parameters) -> String {
-
-    //get the secret key and format as polynomial
+    // Get the secret key and format as polynomial
     let sk_coeffs: Vec<i64> = sk_string
         .split(',')
         .filter_map(|x| x.parse::<i64>().ok())
@@ -28,30 +27,30 @@ pub fn decrypt_string(sk_string: &String, ciphertext_string: &String, params: &P
 
     // Get the ciphertext to be decrypted
     let ciphertext_array: Vec<i64> = ciphertext_string
-    .split(',')
-    .map(|s| s.parse::<i64>().unwrap())
-    .collect();
+        .split(',')
+        .filter_map(|s| s.parse::<i64>().ok())
+        .collect();
 
-    let num_bytes = ciphertext_array.len() / (2 * params.n);
-    let mut decrypted_message = String::new();
+    let num_blocks = ciphertext_array.len() / (2 * params.n);
+    let mut decrypted_bits: Vec<i64> = Vec::new();
 
-    for i in 0..num_bytes {
+    for i in 0..num_blocks {
         let c0 = Polynomial::new(ciphertext_array[2 * i * params.n..(2 * i + 1) * params.n].to_vec());
         let c1 = Polynomial::new(ciphertext_array[(2 * i + 1) * params.n..(2 * i + 2) * params.n].to_vec());
         let ct = [c0, c1];
 
         // Decrypt the ciphertext
-        let decrypted_poly = decrypt(&sk, &ct, &params);
-
-        // Convert the coefficients to characters and append to the message
-        decrypted_message.push_str(
-            &decrypted_poly
-                .coeffs()
-                .iter()
-                .map(|&coeff| coeff as u8 as char)
-                .collect::<String>(),
-        );
+        decrypted_bits.extend(decrypt(&sk, &ct, &params).coeffs());
     }
+
+    // Convert decrypted bits into a string
+    let decrypted_message: String = decrypted_bits
+        .chunks(8)
+        .map(|byte| {
+            let bit_str: String = byte.iter().map(|&b| (b as u8 + b'0') as char).collect();
+            u8::from_str_radix(&bit_str, 2).unwrap_or(0) as char
+        })
+        .collect();
 
     decrypted_message.trim_end_matches('\0').to_string()
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -34,22 +34,16 @@ pub fn encrypt_string(pk_string: &String, message: &String, params: &Parameters,
     let pk_b = Polynomial::new(pk_arr[..params.n].to_vec());
     let pk_a = Polynomial::new(pk_arr[params.n..].to_vec());
     let pk = [pk_b, pk_a];
-
-    // Define the integers to be encrypted
     
-    let message_bytes: Vec<String> = message
+    // Convert each byte into its 8-bit representation (MSB first)
+    let message_bits: Vec<i64> = message
         .bytes()
-        .map(|byte| format!("{:b}", byte))
+        .flat_map(|byte| (0..8).rev().map(move |i| ((byte >> i) & 1) as i64))
         .collect();
 
-    let message_ints: Vec<i64> = message_bytes
-        .iter()
-        .filter_map(|byte| i64::from_str_radix(byte, 2).ok())
-        .collect();
-
-    // Convert message integers into a vector of Polynomials
-    let message_blocks: Vec<Polynomial<i64>> = message_ints
-        .chunks(params.n)
+    // Convert bits into a vector of Polynomials
+    let message_blocks: Vec<Polynomial<i64>> = message_bits
+        .chunks(params.n)  // Pack bits into polynomials of size `n`
         .map(|chunk| Polynomial::new(chunk.to_vec()))
         .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@ pub struct Parameters {
 impl Default for Parameters {
     fn default() -> Self {
         let n = 512;
-        let q = 1048576;
+        let q = 12289;
         let p = 12289;
-        let t = 256;
+        let t = 16;
         let root = 11;
         let omega = omega(root, p, 2*n);
         let mut poly_vec = vec![0i64;n+1];


### PR DESCRIPTION
encode messages using bits rather than bytes to allow for smaller values of t. currently t=16 is okay with even smaller q=12289. need a separate PR to get t=2 working for all tests.