### PR TITLE
ability to set t=2

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -37,24 +37,22 @@ fn benchmark_polymul_small() {
 
 fn benchmark_polymul_uniform() {
     let seed = None; // Set the random seed
-    let p: i64 = 12289; // Prime modulus
-    let root: i64 = 11; // Primitive root of unity for the modulus
     let params = Parameters::default();
-    let omega = omega(root, p, 2*params.n); // n-th root of unity
+    let (n, q, omega) = (params.n, params.q, params.omega);
 
     // Input polynomials (padded to length `n`)
-    let a = gen_uniform_poly(params.n, p, seed);
-    let b = gen_uniform_poly(params.n, p, seed);
+    let a = gen_uniform_poly(n, q, seed);
+    let b = gen_uniform_poly(n, q, seed);
 
     // Time standard multiplication
     let start_std = Instant::now();
-    let c_std = polymul(&a, &b, p, &params.f);
+    let c_std = polymul(&a, &b, q, &params.f);
     let duration_std = start_std.elapsed();
     println!("Standard multiplication (large) took: {:?}", duration_std);
 
     // Time fast multiplication
     let start_fast = Instant::now();
-    let c_fast = polymul_fast(&a, &b, p, &params.f, omega);
+    let c_fast = polymul_fast(&a, &b, q, &params.f, omega);
     let duration_fast = start_fast.elapsed();
     println!("Fast multiplication (large) took: {:?}", duration_fast);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ impl Default for Parameters {
         let n = 512;
         let q = 12289;
         let p = 12289;
-        let t = 16;
+        let t = 2;
         let root = 11;
         let omega = omega(root, p, 2*n);
         let mut poly_vec = vec![0i64;n+1];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,7 @@ use rand::rngs::StdRng;
 #[derive(Debug)]
 pub struct Parameters {
     pub n: usize,       // Polynomial modulus degree
-    pub q: i64,       // Ciphertext composite modulus
-    pub p: i64,      // Ciphertext prime modulus
+    pub q: i64,       // Ciphertext modulus
     pub t: i64,       // Plaintext modulus
     pub root: i64,    // Primitive root of unity
     pub omega: i64,   // n-th root of unity
@@ -20,16 +19,15 @@ impl Default for Parameters {
     fn default() -> Self {
         let n = 512;
         let q = 12289;
-        let p = 12289;
         let t = 2;
         let root = 11;
-        let omega = omega(root, p, 2*n);
+        let omega = omega(root, q, 2*n);
         let mut poly_vec = vec![0i64;n+1];
         poly_vec[0] = 1;
         poly_vec[n] = 1;
         let f = Polynomial::new(poly_vec);
         let sigma = 8.0;
-        Parameters {n, q, p, t, root, omega, f, sigma}
+        Parameters {n, q, t, root, omega, f, sigma}
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -27,20 +27,13 @@ mod tests {
 
         let seed = None; //set the random seed
         let params = Parameters::default();  // Adjust this if needed
+		let (t, f) = (params.t, &params.f);
 
         // Create polynomials from ints
-        let m0_poly = Polynomial::new({
-            let mut v = vec![0i64; params.n];
-            v[0] = 2;
-            v
-        });
-        let m1_poly = Polynomial::new({
-            let mut v = vec![0i64; params.n];
-            v[0] = 3;
-            v
-        });
+        let m0_poly = Polynomial::new(vec![1, 0, 1]);
+        let m1_poly = Polynomial::new(vec![0, 0, 1]);
 
-        let plaintext_sum = &m0_poly + &m1_poly;
+        let plaintext_sum = polyadd(&m0_poly, &m1_poly, t, &f);
         let (pk, sk) = keygen(&params,seed);
 
         // Encrypt plaintext messages
@@ -62,19 +55,11 @@ mod tests {
 
         let seed = None; //set the random seed
         let params = Parameters::default();
-        let (n, q, t, f) = (params.n, params.q, params.t, &params.f);
+        let (q, t, f) = (params.q, params.t, &params.f);
 
         //create polynomials from ints
-        let m0_poly = Polynomial::new({
-            let mut v = vec![0i64; n];
-            v[0] = 2;
-            v
-        });
-        let m1_poly = Polynomial::new({
-            let mut v = vec![0i64; n];
-            v[0] = 3;
-            v
-        });
+        let m0_poly = Polynomial::new(vec![1, 0, 1]);
+        let m1_poly = Polynomial::new(vec![0, 0, 1]);
 
         // Generate the keypair
         let (pk, sk) = keygen(&params,seed);
@@ -83,7 +68,7 @@ mod tests {
         let u = encrypt(&pk, &m0_poly, &params, seed);
         let v = encrypt(&pk, &m1_poly, &params, seed);
 
-        let plaintext_prod = &m0_poly * &m1_poly;
+        let plaintext_prod = polymul(&m0_poly, &m1_poly, t, &f);
         //compute product of encrypted data, using non-standard multiplication
         let c0 = polymul(&u.0,&v.0,q*q,&f);
         let u0v1 = &polymul(&u.0,&v.1,q*q,&f);

--- a/src/test.rs
+++ b/src/test.rs
@@ -113,11 +113,11 @@ mod tests {
         let params = Parameters::default();
     
         // Input polynomials (padded to length `n`)
-        let a = gen_uniform_poly(params.n, params.p, seed);
-        let b = gen_uniform_poly(params.n, params.p, seed);
+        let a = gen_uniform_poly(params.n, params.q, seed);
+        let b = gen_uniform_poly(params.n, params.q, seed);
     
-        let c_std = polymul(&a, &b, params.p, &params.f);
-        let c_fast = polymul_fast(&a, &b, params.p, &params.f, params.omega);
+        let c_std = polymul(&a, &b, params.q, &params.f);
+        let c_fast = polymul_fast(&a, &b, params.q, &params.f, params.omega);
 
         assert_eq!(c_std, c_fast, "test failed: {} != {}", c_std, c_fast);
     }


### PR DESCRIPTION
fixing the nearest_int function allows for `t=2`, but the tests need to be modified since using constants like 2 and 3 which aren't as meaningful mod 2.
 
this PR modifies the homomorphic addition and product tests to use binary polynomials which work for all values of `t`.

we also remove the prime modulus `p` and just have a single ciphertext modulus `q` which is prime, and if not changes would need to be made to ensure the NTT works.