### PR TITLE
update version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-lwe"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Implements the ring learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
update version to 0.1.1. in this version we are using polymul_fast for all multiplications, are using `ntt=0.1.4` which allows for the NTT mod q^2, and the `hom_prod_test` has been appropriately updated and is passing.