### PR TITLE
update to version 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-lwe"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Implements the ring learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
updates the version to 0.1.2. we now use v0.1.8 of `ntt`. root is no longer a parameter, but is computed implicitly by omega. a bug has been resolved for omega when `q=12289` and `n=512`, so now this test case passes. 

now `default-run = ring-lwe`.