### PR TITLE
update to version v.0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-lwe"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Implements the ring learning-with-errors public key encrpytion scheme."
 license = "MIT"
@@ -14,4 +14,4 @@ polynomial-ring = "0.5.0"
 num-traits = "=0.2.19"
 rand = "0.8.5"
 rand_distr = "0.4.3"
-ntt = "0.1.8"
+ntt = "0.1.9"


### PR DESCRIPTION
this changes polysub to have `f` passed by reference for use in `module-lwe`