### PR TITLE
fix degree computations in polymul_fast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,16 @@ pub fn polymul_fast(
     f: &Polynomial<i64>, 
     omega: i64
 ) -> Polynomial<i64> {
-    // Compute the degree and padded coefficients
-    let n = 2 * (x.deg().unwrap() + 1);
+    let n1 = x.coeffs().len();
+    let n2 = y.coeffs().len();
+    // Compute the nearest power of 2 larger than twice the max of input degrees+1
+    let log = std::cmp::max(n1, n2).ilog2();
+    let mut n = 2usize.pow(log);
+    if n < std::cmp::max(n1, n2) {
+        n *= 2;
+    }
+    n *= 2;
+    // Pad coefficients
     let x_pad = {
         let mut coeffs = x.coeffs().to_vec();
         coeffs.resize(n, 0);


### PR DESCRIPTION
now manually computes the nearest power of 2 at least twice the max of input degrees+1