### PR TITLE
update to v0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-lwe"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Implements the ring learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
reorganizes functions from `lib.rs` into `utils.rs`, publicly exposing all functions.