### PR TITLE
suppress warning for polymul

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,6 +86,7 @@ pub fn polyrem(x: Polynomial<i64>, f: &Polynomial<i64>) -> Polynomial<i64> {
 ///	* `f` - polynomial modulus.
 /// # Returns:
 ///	polynomial in Z_q[X]/(f)
+#[allow(dead_code)]
 pub fn polymul(x : &Polynomial<i64>, y : &Polynomial<i64>, q : i64, f : &Polynomial<i64>) -> Polynomial<i64> {
 	let mut r = x*y;
     r = polyrem(r,f);


### PR DESCRIPTION
suppress warning for polymul. it's used in `cargo test`, but not in `cargo run` since we replaced it with `polymul_fast`