### PR TITLE
update to v0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-lwe"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Implements the ring learning-with-errors public key encrpytion scheme."
 license = "MIT"


### PR DESCRIPTION
adds criterion benchmarking for `keygen`, `encrypt`, `decrypt`, `polymul_fast`