### PR TITLE
Use base64 encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ num-traits = "=0.2.19"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 ntt = "0.1.9"
+base64 = "0.21"
+bincode = "1.3"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -40,7 +40,7 @@ pub fn decrypt(
 /// * `ciphertext_string` - ciphertext to decrypt as a base64 encoded string
 /// * `params` - ring-LWE parameters
 /// # Returns:
-///	decrypted message
+///	decrypted plaintext message
 /// # Example:
 /// ```
 /// let params = ring_lwe::utils::Parameters::default();

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -36,8 +36,8 @@ pub fn decrypt(
 
 /// Decrypt a ciphertext string using the secret key
 /// # Arguments:
-/// * `sk_string` - secret key as a comma-separated string
-/// * `ciphertext_string` - ciphertext to decrypt as a comma-separated string
+/// * `sk_string` - secret key as a base64 encoded string
+/// * `ciphertext_string` - ciphertext to decrypt as a base64 encoded string
 /// * `params` - ring-LWE parameters
 /// # Returns:
 ///	decrypted message
@@ -51,21 +51,25 @@ pub fn decrypt(
 /// let ciphertext_string = ring_lwe::encrypt::encrypt_string(pk_string, &message, &params, None);
 /// let decrypted_message = ring_lwe::decrypt::decrypt_string(sk_string, &ciphertext_string, &params);
 /// ```
-pub fn decrypt_string(sk_base64: &String, ciphertext_string: &String, params: &Parameters) -> String {
+pub fn decrypt_string(sk_base64: &String, ciphertext_base64: &String, params: &Parameters) -> String {
     // Decode the Base64 secret key string
-    let sk_bytes = general_purpose::STANDARD.decode(sk_base64).expect("Failed to decode Base64 secret key");
+    let sk_bytes = general_purpose::STANDARD.decode(sk_base64)
+        .expect("Failed to decode Base64 secret key");
 
     // Deserialize the binary data into a vector of i64 coefficients
-    let sk_coeffs: Vec<i64> = bincode::deserialize(&sk_bytes).expect("Failed to deserialize secret key");
+    let sk_coeffs: Vec<i64> = bincode::deserialize(&sk_bytes)
+        .expect("Failed to deserialize secret key");
 
     // Reconstruct the secret key polynomial
     let sk = Polynomial::new(sk_coeffs);
 
-    // Parse the ciphertext string into coefficients
-    let ciphertext_array: Vec<i64> = ciphertext_string
-        .split(',')
-        .filter_map(|s| s.parse::<i64>().ok())
-        .collect();
+    // Decode the Base64 ciphertext string
+    let ciphertext_bytes = general_purpose::STANDARD.decode(ciphertext_base64)
+        .expect("Failed to decode Base64 ciphertext");
+
+    // Deserialize the binary ciphertext into a vector of i64 coefficients
+    let ciphertext_array: Vec<i64> = bincode::deserialize(&ciphertext_bytes)
+        .expect("Failed to deserialize ciphertext");
 
     let num_blocks = ciphertext_array.len() / (2 * params.n);
     let mut decrypted_bits: Vec<i64> = Vec::new();

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -1,5 +1,7 @@
-use polynomial_ring::Polynomial;
 use crate::utils::{Parameters, mod_coeffs, polymul_fast, polyadd, gen_ternary_poly};
+use polynomial_ring::Polynomial;
+use base64::{engine::general_purpose, Engine as _};
+use bincode;
 
 /// Encrypt a polynomial using the public key
 /// # Arguments:
@@ -54,18 +56,18 @@ pub fn encrypt(
 /// let message = String::from("hello");
 /// let ciphertext_string = ring_lwe::encrypt::encrypt_string(pk_string, &message, &params, None);
 /// ```
-pub fn encrypt_string(pk_string: &String, message: &String, params: &Parameters, seed: Option<u64>) -> String {
+pub fn encrypt_string(pk_base64: &String, message: &String, params: &Parameters, seed: Option<u64>) -> String {
+    // Decode the Base64 public key string
+    let pk_bytes = general_purpose::STANDARD.decode(pk_base64).expect("Failed to decode Base64 public key");
+    
+    // Deserialize the binary data into a vector of i64 coefficients
+    let pk_arr: Vec<i64> = bincode::deserialize(&pk_bytes).expect("Failed to deserialize public key");
 
-    // Get the public key from the string and format as two Polynomials
-    let pk_arr: Vec<i64> = pk_string
-        .split(',')
-        .filter_map(|x| x.parse::<i64>().ok())
-        .collect();
-
+    // Split the public key into two polynomials
     let pk_b = Polynomial::new(pk_arr[..params.n].to_vec());
     let pk_a = Polynomial::new(pk_arr[params.n..].to_vec());
     let pk = [pk_b, pk_a];
-    
+
     // Convert each byte into its 8-bit representation (MSB first)
     let message_bits: Vec<i64> = message
         .bytes()
@@ -74,7 +76,7 @@ pub fn encrypt_string(pk_string: &String, message: &String, params: &Parameters,
 
     // Convert bits into a vector of Polynomials
     let message_blocks: Vec<Polynomial<i64>> = message_bits
-        .chunks(params.n)  // Pack bits into polynomials of size `n`
+        .chunks(params.n) // Pack bits into polynomials of size `n`
         .map(|chunk| Polynomial::new(chunk.to_vec()))
         .collect();
 
@@ -92,5 +94,6 @@ pub fn encrypt_string(pk_string: &String, message: &String, params: &Parameters,
         .map(|x| x.to_string())
         .collect::<Vec<String>>()
         .join(",");
+
     ciphertext_string
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -42,7 +42,7 @@ pub fn encrypt(
 
 /// Encrypt a string using the public key
 /// # Arguments:
-/// * `pk_string` - public key as a comma-separated string
+/// * `pk_string` - public key as a base64 encoded string
 /// * `message` - message to encrypt
 /// * `params` - ring-LWE parameters
 /// * `seed` - random seed

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -47,7 +47,7 @@ pub fn encrypt(
 /// * `params` - ring-LWE parameters
 /// * `seed` - random seed
 /// # Returns:
-///	encrypted message as a comma-separated string
+///	encrypted message as a base64 encoded string
 /// # Example:
 /// ```
 /// let params = ring_lwe::utils::Parameters::default();
@@ -58,10 +58,12 @@ pub fn encrypt(
 /// ```
 pub fn encrypt_string(pk_base64: &String, message: &String, params: &Parameters, seed: Option<u64>) -> String {
     // Decode the Base64 public key string
-    let pk_bytes = general_purpose::STANDARD.decode(pk_base64).expect("Failed to decode Base64 public key");
+    let pk_bytes = general_purpose::STANDARD.decode(pk_base64)
+        .expect("Failed to decode Base64 public key");
     
     // Deserialize the binary data into a vector of i64 coefficients
-    let pk_arr: Vec<i64> = bincode::deserialize(&pk_bytes).expect("Failed to deserialize public key");
+    let pk_arr: Vec<i64> = bincode::deserialize(&pk_bytes)
+        .expect("Failed to deserialize public key");
 
     // Split the public key into two polynomials
     let pk_b = Polynomial::new(pk_arr[..params.n].to_vec());
@@ -88,12 +90,12 @@ pub fn encrypt_string(pk_base64: &String, message: &String, params: &Parameters,
         ciphertext_list.extend(ciphertext[1].coeffs());
     }
 
-    // Format the ciphertext list as a comma-separated string
-    let ciphertext_string = ciphertext_list
-        .iter()
-        .map(|x| x.to_string())
-        .collect::<Vec<String>>()
-        .join(",");
+    // Serialize the ciphertext list to binary
+    let ciphertext_bytes = bincode::serialize(&ciphertext_list)
+        .expect("Failed to serialize ciphertext");
 
-    ciphertext_string
+    // Encode the binary ciphertext as Base64
+    let ciphertext_base64 = general_purpose::STANDARD.encode(&ciphertext_bytes);
+
+    ciphertext_base64
 }

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -1,6 +1,7 @@
-use polynomial_ring::Polynomial;
 use crate::utils::{Parameters, polymul_fast, polyadd, polyinv, gen_ternary_poly, gen_uniform_poly};
+use polynomial_ring::Polynomial;
 use std::collections::HashMap;
+use base64::{engine::general_purpose, Engine as _};
 
 /// Generate a public and secret key pair
 /// # Arguments:
@@ -41,30 +42,25 @@ pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], 
 /// let pk_string = keys.get("public").unwrap();
 /// let sk_string = keys.get("secret").unwrap();
 /// ```
-pub fn keygen_string(params: &Parameters, seed: Option<u64>) -> HashMap<String,String> {
+pub fn keygen_string(params: &Parameters, seed: Option<u64>) -> HashMap<String, String> {
+    // Generate keys using parameters
+    let (pk, sk) = keygen(params, seed);
 
-    // generate keys using parameters
-    let (pk, sk) = keygen(params,seed);
-
-    let mut pk_coeffs: Vec<i64> = Vec::with_capacity(2*params.n);
+    let mut pk_coeffs: Vec<i64> = Vec::with_capacity(2 * params.n);
     pk_coeffs.extend(pk[0].coeffs());
     pk_coeffs.extend(pk[1].coeffs());
 
-    // Convert the public key coefficients to a comma-separated string
-    let pk_coeffs_str = pk_coeffs.iter()
-            .map(|coef| coef.to_string())
-            .collect::<Vec<String>>()
-            .join(",");
-    
-    // Convert the secret key coefficients to a comma-separated string
-    let sk_coeffs_str = sk.coeffs().iter()
-            .map(|coef| coef.to_string())
-            .collect::<Vec<String>>()
-            .join(",");
-    
-    //store public/secret keys in HashMap
+    // Serialize the coefficients as binary data
+    let pk_bytes = bincode::serialize(&pk_coeffs).expect("Failed to serialize public key");
+    let sk_bytes = bincode::serialize(&sk.coeffs()).expect("Failed to serialize secret key");
+
+    // Encode the binary data to Base64
+    let pk_base64 = general_purpose::STANDARD.encode(&pk_bytes);
+    let sk_base64 = general_purpose::STANDARD.encode(&sk_bytes);
+
+    // Store public/secret keys in a HashMap
     let mut keys: HashMap<String, String> = HashMap::new();
-    keys.insert(String::from("secret"), sk_coeffs_str);
-    keys.insert(String::from("public"), pk_coeffs_str);
+    keys.insert(String::from("secret"), sk_base64);
+    keys.insert(String::from("public"), pk_base64);
     keys
 }

--- a/src/keygen.rs
+++ b/src/keygen.rs
@@ -34,7 +34,7 @@ pub fn keygen(params: &Parameters, seed: Option<u64>) -> ([Polynomial<i64>; 2], 
 ///	* `params` - ring-LWE parameters
 /// * `seed` - random seed
 /// # Returns:
-///	HashMap containing public and secret keys
+///	HashMap containing public and secret keys as base64 encoded strings
 /// # Example:
 /// ```
 /// let params = ring_lwe::utils::Parameters::default();


### PR DESCRIPTION
use `base64::{engine::general_purpose, Engine as _}` and `bincode` for base64 encoding of public key, secret key, and ciphertext strings. this is much more efficient than using comma-separated strings of digits, and also avoids commas. 